### PR TITLE
Include Backward compatibility only on PS 1.4

### DIFF
--- a/ogone.php
+++ b/ogone.php
@@ -145,7 +145,9 @@ class Ogone extends PaymentModule
 
 		$this->description = $this->l($desc);
 		/* Backward compatibility */
-		require_once _PS_MODULE_DIR_.'ogone/backward_compatibility/backward.php';
+		if (version_compare(_PS_VERSION_, '1.5', '<')) {
+			require_once _PS_MODULE_DIR_.'ogone/backward_compatibility/backward.php';
+		}
 	}
 
 	public function install()


### PR DESCRIPTION
On PrestaShop 1.4, the function FrontController::setTemplate has not the same signature.

If we want to make module still working on this version, we add a test to not include the backward compatibility on PS 1.5+
